### PR TITLE
Correct bug that causes bars of previous canvas to be displayed if a new tree is made

### DIFF
--- a/jsphylosvg.js
+++ b/jsphylosvg.js
@@ -646,6 +646,9 @@ Smits.PhyloCanvas.NewickParse.prototype = {
 								Smits.PhyloCanvas.Render.Parameters.integratedBinaryCharts.push(charts[i][j]);								
 							} else if (charts[i][j].type == "bar"){
 								charts[i][j].chart = i;
+                                if (Smits.PhyloCanvas.Render.Parameters.barCharts.length == 1){
+                                    Smits.PhyloCanvas.Render.Parameters.barCharts.shift();
+                                }
 								Smits.PhyloCanvas.Render.Parameters.barCharts.push(charts[i][j]);
 							}
 						}


### PR DESCRIPTION
Saw this problem when changing the size of the phylogram. This removes barChart array from the previous phylocanvas, which persists despite removing the previous phylocanvas.
