### PR TITLE
Prevent previous bar charts from showing in rerender

### DIFF
--- a/jsphylosvg.js
+++ b/jsphylosvg.js
@@ -1577,6 +1577,10 @@ Smits.PhyloCanvas.Render.SVG.prototype = {
 				outerRadius = renderBarChart(outerX, barCharts[i].chart, barCharts[i]);
 			}
 		}				
+        
+        // Clear vars so they don't get pushed to if rerender
+        labelsHold = [];
+        bgLabelsHold = [];
 
 	}
 }();
@@ -2102,6 +2106,10 @@ Smits.PhyloCanvas.Render.Phylogram.prototype = {
 				outerRadius = renderBarChart(outerRadius, barCharts[i].chart, barCharts[i]);
 			}
 		}		
+
+        // Clear vars so they don't get pushed to if rerender
+        labelsHold = [];
+        bgLabelsHold = [];
 
 	}
 })();


### PR DESCRIPTION
This should prevent rerendering of same data from showing barcharts from the previous render (e.g. if you replot and only change the size of the phylogram).
